### PR TITLE
Infl 5170 split auth into separate module

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,15 @@ provider "aws" {
 }
 
 
+module "firefly_auth" {
+  source = "github.com/gofireflyio/terraform-firefly-aws-onboarding?ref=v1.1.0"
+  firefly_access_key    = "YOUR_ACCESS_KEY"
+  firefly_secret_key    = "YOUR_SECRET_KEY"
+}
+
 module "firefly-read-only" {
   source              = "github.com/gofireflyio/terraform-firefly-aws-onboarding?ref=v1.1.0"
-  firefly_access_key  = "YOUR_ACCESS_KEY"
-  firefly_secret_key  = "YOUR_SECRET_KEY"
+  firefly_token         = module.firefly_auth.firefly_token
   role_external_id    = "YOUR_EXTERNAL_ID"
   is_prod               = false/true
 }
@@ -38,11 +43,15 @@ provider "aws" {
     region     =  "us-east-1"
 }
 
+module "firefly_auth" {
+  source = "github.com/gofireflyio/terraform-firefly-aws-onboarding?ref=v1.1.0"
+  firefly_access_key    = "YOUR_ACCESS_KEY"
+  firefly_secret_key    = "YOUR_SECRET_KEY"
+}
 
 module "firefly-read-only" {
   source               = "github.com/gofireflyio/terraform-firefly-aws-onboarding?ref=v1.1.0"
-  firefly_access_key   = "YOUR_ACCESS_KEY"
-  firefly_secret_key   = "YOUR_SECRET_KEY"
+  firefly_token         = module.firefly_auth.firefly_token
   role_external_id     = "YOUR_EXTERNAL_ID"
   is_prod              = false/true
   is_event_driven      = true
@@ -58,11 +67,16 @@ provider "aws" {
     region     =  "us-east-1"
 }
 
+module "firefly_auth" {
+  source = "github.com/gofireflyio/terraform-firefly-aws-onboarding?ref=v1.1.0"
+  firefly_access_key    = "YOUR_ACCESS_KEY"
+  firefly_secret_key    = "YOUR_SECRET_KEY"
+}
+
 
 module "firefly-read-only" {
   source               = "github.com/gofireflyio/terraform-firefly-aws-onboarding?ref=v1.1.0"
-  firefly_access_key   = "YOUR_ACCESS_KEY"
-  firefly_secret_key   = "YOUR_SECRET_KEY"
+  firefly_token         = module.firefly_auth.firefly_token
   role_external_id     = "YOUR_EXTERNAL_ID"
   is_prod              = false/true
   is_event_driven      = true
@@ -88,6 +102,9 @@ exist_integration = true
 ```
 
 ### Optional
+You can add optionally add tags to each relevant resource:
+tags = {vendor: "firefly"}
+
 AWS credentials will be default unless adding one of the following params to the configuration:
 ```
 profile = "YOUR_PROFILE"

--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ provider "aws" {
 
 
 module "firefly_auth" {
-  source = "github.com/gofireflyio/terraform-firefly-aws-onboarding?ref=v1.1.0"
+  source = "github.com/gofireflyio/terraform-firefly-aws-onboarding?ref=v1.5.0/modules/firefly_auth"
   firefly_access_key    = "YOUR_ACCESS_KEY"
   firefly_secret_key    = "YOUR_SECRET_KEY"
 }
 
 module "firefly-read-only" {
-  source              = "github.com/gofireflyio/terraform-firefly-aws-onboarding?ref=v1.1.0"
+  source              = "github.com/gofireflyio/terraform-firefly-aws-onboarding?ref=v1.5.0"
   firefly_token         = module.firefly_auth.firefly_token
   role_external_id    = "YOUR_EXTERNAL_ID"
   is_prod               = false/true
@@ -44,14 +44,14 @@ provider "aws" {
 }
 
 module "firefly_auth" {
-  source = "github.com/gofireflyio/terraform-firefly-aws-onboarding?ref=v1.1.0"
+  source = "github.com/gofireflyio/terraform-firefly-aws-onboarding?ref=v1.5.0/modules/firefly_auth"
   firefly_access_key    = "YOUR_ACCESS_KEY"
   firefly_secret_key    = "YOUR_SECRET_KEY"
 }
 
 module "firefly-read-only" {
-  source               = "github.com/gofireflyio/terraform-firefly-aws-onboarding?ref=v1.1.0"
-  firefly_token         = module.firefly_auth.firefly_token
+  source               = "github.com/gofireflyio/terraform-firefly-aws-onboarding?ref=v1.5.0"
+  firefly_token        = module.firefly_auth.firefly_token
   role_external_id     = "YOUR_EXTERNAL_ID"
   is_prod              = false/true
   is_event_driven      = true
@@ -68,14 +68,14 @@ provider "aws" {
 }
 
 module "firefly_auth" {
-  source = "github.com/gofireflyio/terraform-firefly-aws-onboarding?ref=v1.1.0"
+  source = "github.com/gofireflyio/terraform-firefly-aws-onboarding?ref=v1.5.0/modules/firefly_auth"
   firefly_access_key    = "YOUR_ACCESS_KEY"
   firefly_secret_key    = "YOUR_SECRET_KEY"
 }
 
 
 module "firefly-read-only" {
-  source               = "github.com/gofireflyio/terraform-firefly-aws-onboarding?ref=v1.1.0"
+  source               = "github.com/gofireflyio/terraform-firefly-aws-onboarding?ref=v1.5.0"
   firefly_token         = module.firefly_auth.firefly_token
   role_external_id     = "YOUR_EXTERNAL_ID"
   is_prod              = false/true

--- a/main.tf
+++ b/main.tf
@@ -452,6 +452,7 @@ module "firefly_eventbridge_permissions" {
   providers          = {
     aws = aws.us_east_1
   }
+  tags = var.tags
 }
 
 // create eventbridge rules using workflow for exist integration
@@ -483,6 +484,7 @@ module "event_driven_ap_northeast_1" {
   providers      = {
     aws = aws.ap_northeast_1
   }
+  tags = var.tags
 }
 
 module "event_driven_ap_northeast_2" {
@@ -499,6 +501,7 @@ module "event_driven_ap_northeast_2" {
   providers      = {
     aws = aws.ap_northeast_2
   }
+  tags = var.tags
 }
 
 module "event_driven_ap_northeast_3" {
@@ -515,6 +518,8 @@ module "event_driven_ap_northeast_3" {
   providers      = {
     aws = aws.ap_northeast_3
   }
+
+  tags = var.tags
 }
 
 module "event_driven_ap_south_1" {
@@ -531,6 +536,7 @@ module "event_driven_ap_south_1" {
   providers      = {
     aws = aws.ap_south_1
   }
+  tags = var.tags
 }
 
 module "event_driven_ap_southeast_1" {
@@ -547,6 +553,7 @@ module "event_driven_ap_southeast_1" {
   providers      = {
     aws = aws.ap_southeast_1
   }
+  tags = var.tags
 }
 
 module "event_driven_ap_southeast_2" {
@@ -563,6 +570,7 @@ module "event_driven_ap_southeast_2" {
   providers      = {
     aws = aws.ap_southeast_2
   }
+  tags = var.tags
 }
 
 module "event_driven_ca_central_1" {
@@ -579,6 +587,7 @@ module "event_driven_ca_central_1" {
   providers      = {
     aws = aws.ca_central_1
   }
+  tags = var.tags
 }
 
 module "event_driven_eu_central_1" {
@@ -595,6 +604,8 @@ module "event_driven_eu_central_1" {
   providers      = {
     aws = aws.eu_central_1
   }
+
+  tags = var.tags
 }
 
 module "event_driven_eu_north_1" {
@@ -611,6 +622,7 @@ module "event_driven_eu_north_1" {
   providers      = {
     aws = aws.eu_north_1
   }
+  tags = var.tags
 }
 
 module "event_driven_eu_west_1" {
@@ -627,6 +639,8 @@ module "event_driven_eu_west_1" {
   providers      = {
     aws = aws.eu_west_1
   }
+
+  tags = var.tags
 }
 
 module "event_driven_eu_west_2" {
@@ -643,6 +657,7 @@ module "event_driven_eu_west_2" {
   providers      = {
     aws = aws.eu_west_2
   }
+  tags = var.tags
 }
 
 module "event_driven_eu_west_3" {
@@ -659,6 +674,7 @@ module "event_driven_eu_west_3" {
   providers      = {
     aws = aws.eu_west_3
   }
+  tags = var.tags
 }
 
 module "event_driven_sa_east_1" {
@@ -675,6 +691,7 @@ module "event_driven_sa_east_1" {
   providers      = {
     aws = aws.sa_east_1
   }
+  tags = var.tags
 }
 
 module "event_driven_us_east_1" {
@@ -691,6 +708,7 @@ module "event_driven_us_east_1" {
   providers      = {
     aws = aws.us_east_1
   }
+  tags = var.tags
 }
 
 module "event_driven_us_east_2" {
@@ -707,6 +725,7 @@ module "event_driven_us_east_2" {
   providers      = {
     aws = aws.us_east_2
   }
+  tags = var.tags
 }
 
 module "event_driven_us_west_1" {
@@ -723,6 +742,7 @@ module "event_driven_us_west_1" {
   providers      = {
     aws = aws.us_west_1
   }
+  tags = var.tags
 }
 
 module "event_driven_us_west_2" {
@@ -739,6 +759,7 @@ module "event_driven_us_west_2" {
   providers      = {
     aws = aws.us_west_2
   }
+  tags = var.tags
 }
 
 module "iac_events_ap_northeast_1" {
@@ -937,4 +958,5 @@ module "config_service_setup" {
     aws = aws.us_east_1
   }
   firefly_role_name = var.firefly_role_name
+  tags = var.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -423,10 +423,8 @@ provider "aws" {
 }
 
 module "firefly_aws_integration" {
-  count = var.exist_integration? 0 : 1
   source = "./modules/firefly_aws_integration"
-  firefly_secret_key = var.firefly_secret_key
-  firefly_access_key = var.firefly_access_key
+  firefly_token = var.firefly_token
   name = var.name
   firefly_endpoint = var.firefly_endpoint
   event_driven = var.is_event_driven
@@ -460,8 +458,7 @@ module "firefly_eventbridge_permissions" {
 module "run_workflow" {
   count = var.is_event_driven && !var.terraform_create_rules && var.exist_integration ? 1 : 0
   source = "./modules/run_workflow"
-  firefly_secret_key = var.firefly_secret_key
-  firefly_access_key = var.firefly_access_key
+  firefly_token = var.firefly_token
   name = var.name
   firefly_endpoint = var.firefly_endpoint
   events_role_arn = module.firefly_eventbridge_permissions[0].eventbridge_rule_role_arn

--- a/main.tf
+++ b/main.tf
@@ -422,10 +422,18 @@ provider "aws" {
 
 }
 
+module "firefly_auth" {
+  count = var.firefly_token == "" ? 1 : 0
+  source = "./modules/firefly_auth"
+  firefly_endpoint = var.firefly_endpoint
+  firefly_access_key = var.firefly_access_key
+  firefly_secret_key = var.firefly_secret_key
+}
+
 module "firefly_aws_integration" {
   count = var.exist_integration? 0 : 1
   source = "./modules/firefly_aws_integration"
-  firefly_token = var.firefly_token
+  firefly_token = length(module.firefly_auth) > 0 ? module.firefly_auth[0].firefly_token : var.firefly_token
   name = var.name
   firefly_endpoint = var.firefly_endpoint
   event_driven = var.is_event_driven

--- a/main.tf
+++ b/main.tf
@@ -423,6 +423,7 @@ provider "aws" {
 }
 
 module "firefly_aws_integration" {
+  count = var.exist_integration? 0 : 1
   source = "./modules/firefly_aws_integration"
   firefly_token = var.firefly_token
   name = var.name

--- a/modules/config_service_setup/main.tf
+++ b/modules/config_service_setup/main.tf
@@ -32,6 +32,7 @@ resource "aws_iam_policy" "config_service_management_policy" {
       }
     ]
   })
+  tags = var.tags
 }
 
 resource "aws_iam_role" "aws_config_role" {
@@ -58,11 +59,13 @@ POLICY
     "arn:aws:iam::aws:policy/SecurityAudit",
     "arn:aws:iam::aws:policy/ReadOnlyAccess",
   ]
+  tags = var.tags
 }
 
 resource "aws_s3_bucket" "config_bucket" {
   bucket        = "aws-config-service-bucket-${data.aws_caller_identity.current.account_id}"
   force_destroy = true
+  tags = var.tags
 }
 
 resource "aws_iam_policy" "config_service_firefly_permissions" {
@@ -96,6 +99,7 @@ resource "aws_iam_policy" "config_service_firefly_permissions" {
       }
     ]
   })
+  tags = var.tags
 }
 
 resource "aws_iam_role_policy_attachment" "firefly_config_service_permissions" {

--- a/modules/config_service_setup/vars.tf
+++ b/modules/config_service_setup/vars.tf
@@ -5,3 +5,9 @@ variable "firefly_deny_policy_name" {
 variable "firefly_role_name"{
   type = string
 }
+
+variable "tags" {
+  type = map
+  default = {}
+  description = "Tags to apply to all created AWS resources"
+}

--- a/modules/eventbridge_permissions/main.tf
+++ b/modules/eventbridge_permissions/main.tf
@@ -31,11 +31,13 @@ resource "aws_iam_policy" "firefly_eventbridge_permission" {
           }
     ]
   })
+  tags = var.tags
 }
 
 resource "aws_iam_role_policy_attachment" "firefly_eventbridge_permissions" {
   role       = var.firefly_role_name
   policy_arn = aws_iam_policy.firefly_eventbridge_permission.arn
+
 }
 
 
@@ -56,6 +58,7 @@ resource "aws_iam_role" "invoke_firefly_event_bus" {
   ]
 }
 EOF
+  tags = var.tags
 }
 
 resource "aws_iam_policy" "invoke_firefly_event_bus" {
@@ -72,6 +75,7 @@ resource "aws_iam_policy" "invoke_firefly_event_bus" {
         }
     ]
   })
+  tags = var.tags
 }
 
 resource "aws_iam_role_policy_attachment" "invoke_firefly_event_bus" {

--- a/modules/eventbridge_permissions/vars.tf
+++ b/modules/eventbridge_permissions/vars.tf
@@ -5,3 +5,9 @@ variable "target_event_bus_arn"{
 variable "firefly_role_name"{
   type = string
 }
+
+variable "tags" {
+  type = map
+  default = {}
+  description = "Tags to apply to all created AWS resources"
+}

--- a/modules/firefly_auth/main.tf
+++ b/modules/firefly_auth/main.tf
@@ -1,0 +1,9 @@
+data "terracurl_request" "firefly_login" {
+  name           = "firefly_aws_integration"
+  url            = "${var.firefly_endpoint}/account/access_keys/login"
+  method         = "POST"
+  headers        = {
+    Content-Type: "application/json",
+  }
+  request_body = jsonencode({ "accessKey"=var.firefly_access_key,  "secretKey"=var.firefly_secret_key })
+}

--- a/modules/firefly_auth/output.tf
+++ b/modules/firefly_auth/output.tf
@@ -1,0 +1,3 @@
+output "firefly_token" {
+  value = jsondecode(data.terracurl_request.firefly_login.response).access_token
+}

--- a/modules/firefly_auth/terraform.tf
+++ b/modules/firefly_auth/terraform.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    terracurl = {
+      version = "0.1.0"
+      source= "devops-rob/terracurl"
+    }
+  }
+}

--- a/modules/firefly_auth/vars.tf
+++ b/modules/firefly_auth/vars.tf
@@ -7,9 +7,17 @@ variable "firefly_endpoint" {
 variable "firefly_access_key" {
   type        = string
   description = "Your authentication access_key"
+  validation {
+    condition = var.firefly_access_key != ""
+    error_message = "firefly_access_key cannot be empty"
+  }
 }
 
 variable "firefly_secret_key" {
   type        = string
   description = "Your authentication secret_key"
+  validation {
+    condition = var.firefly_secret_key != ""
+    error_message = "firefly_secret_key cannot be empty"
+  }
 }

--- a/modules/firefly_auth/vars.tf
+++ b/modules/firefly_auth/vars.tf
@@ -1,0 +1,15 @@
+variable "firefly_endpoint" {
+  type        = string
+  description = "The Firefly endpoint to register account management"
+  default     = "https://prodapi.gofirefly.io/api"
+}
+
+variable "firefly_access_key" {
+  type        = string
+  description = "Your authentication access_key"
+}
+
+variable "firefly_secret_key" {
+  type        = string
+  description = "Your authentication secret_key"
+}

--- a/modules/firefly_aws_integration/iam.tf
+++ b/modules/firefly_aws_integration/iam.tf
@@ -147,6 +147,7 @@ resource "aws_iam_policy" "firefly_readonly_policy_deny_list" {
         },
     ]
   })
+  tags = var.tags
 }
 
 locals {
@@ -190,6 +191,7 @@ resource "aws_iam_policy" "firefly_s3_specific_permission" {
       },
     ]
   })
+  tags = var.tags
 }
 
 resource "aws_iam_role" "firefly_cross_account_access_role" {
@@ -211,6 +213,7 @@ resource "aws_iam_role" "firefly_cross_account_access_role" {
       }
     ]
   })
+  tags = var.tags
 }
 
 resource "aws_iam_role_policy_attachment" "firefly_readonly_policy_deny_list" {

--- a/modules/firefly_aws_integration/main.tf
+++ b/modules/firefly_aws_integration/main.tf
@@ -1,23 +1,3 @@
-
-data "terracurl_request" "firefly_login" {
-  name           = "firefly_aws_integration"
-  url            = "${var.firefly_endpoint}/account/access_keys/login"
-  method         = "POST"
-  headers        = {
-    Content-Type: "application/json",
-  }
-  request_body = jsonencode({ "accessKey"=var.firefly_access_key,  "secretKey"=var.firefly_secret_key })
-
-}
-
-output "token" {
-  value = jsondecode(data.terracurl_request.firefly_login.response).access_token
-}
-
-output "response_code" {
-  value = data.terracurl_request.firefly_login.response
-}
-
 resource "time_sleep" "wait_10_seconds" {
   depends_on = [
     aws_iam_policy.firefly_readonly_policy_deny_list, aws_iam_policy.firefly_s3_specific_permission,
@@ -46,7 +26,7 @@ resource "terracurl_request" "firefly_aws_integration_request" {
 
   headers = {
     Content-Type = "application/json"
-    Authorization: "Bearer ${jsondecode(data.terracurl_request.firefly_login.response).access_token}"
+    Authorization: "Bearer ${var.firefly_token}"
   }
 
    lifecycle {

--- a/modules/firefly_aws_integration/vars.tf
+++ b/modules/firefly_aws_integration/vars.tf
@@ -77,3 +77,9 @@ variable "terraform_create_rules" {
   type = bool
   default = false
 }
+
+variable "tags" {
+  type = map
+  default = {}
+  description = "Tags to apply to all created AWS resources"
+}

--- a/modules/firefly_aws_integration/vars.tf
+++ b/modules/firefly_aws_integration/vars.tf
@@ -1,11 +1,19 @@
 variable "firefly_access_key" {
   type        = string
   description = "Your authentication access_key"
+  default = ""
 }
 
 variable "firefly_secret_key" {
   type        = string
   description = "Your authentication secret_key"
+  default = ""
+}
+
+variable "firefly_token" {
+  type = string
+  description = "Token returned as result of login request, if provided firefly_access_key and firefly_secret_key are ignored"
+  default = ""
 }
 
 variable "name" {

--- a/modules/firefly_event_driven/main.tf
+++ b/modules/firefly_event_driven/main.tf
@@ -8,6 +8,7 @@ module "rule" {
     service_regions = each.value["regions"]
     target_event_bus_arn = var.target_event_bus_arn
     eventbridge_role_arn = var.eventbridge_role_arn
+    tags = var.tags
 } 
 
 module "no_actions_rule" {
@@ -19,4 +20,5 @@ module "no_actions_rule" {
     service_regions = each.value["regions"]
     target_event_bus_arn = var.target_event_bus_arn
     eventbridge_role_arn = var.eventbridge_role_arn
+    tags = var.tags
 } 

--- a/modules/firefly_event_driven/modules/eventbridge_rule/main.tf
+++ b/modules/firefly_event_driven/modules/eventbridge_rule/main.tf
@@ -11,4 +11,5 @@ module "rule" {
       "eventName" : var.rules
     }
   })
+  tags = var.tags
 }

--- a/modules/firefly_event_driven/modules/eventbridge_rule/vars.tf
+++ b/modules/firefly_event_driven/modules/eventbridge_rule/vars.tf
@@ -25,3 +25,9 @@ variable "target_event_bus_arn"{
 variable "eventbridge_role_arn"{
   type = string
 }
+
+variable "tags" {
+  type = map
+  default = {}
+  description = "Tags to apply to all created AWS resources"
+}

--- a/modules/firefly_event_driven/modules/no_actions_eventbridge_rule/main.tf
+++ b/modules/firefly_event_driven/modules/no_actions_eventbridge_rule/main.tf
@@ -11,4 +11,5 @@ module "rule" {
       "readOnly" : [false]
     }
   })
+  tags = var.tags
 }

--- a/modules/firefly_event_driven/modules/no_actions_eventbridge_rule/vars.tf
+++ b/modules/firefly_event_driven/modules/no_actions_eventbridge_rule/vars.tf
@@ -21,3 +21,9 @@ variable "service_regions"{
 variable "eventbridge_role_arn"{
   type = string
 }
+
+variable "tags" {
+  type = map
+  default = {}
+  description = "Tags to apply to all created AWS resources"
+}

--- a/modules/firefly_event_driven/modules/rule/main.tf
+++ b/modules/firefly_event_driven/modules/rule/main.tf
@@ -2,6 +2,7 @@ resource "aws_cloudwatch_event_rule" "rule" {
   name        = "firefly-events-${var.rule_name}"
   description = "${var.service} Cloud Trail to Firefly event bus"
   event_pattern = var.event_pattarn
+  tags = var.tags
 }
 
 resource "aws_cloudwatch_event_target" "target" {

--- a/modules/firefly_event_driven/modules/rule/vars.tf
+++ b/modules/firefly_event_driven/modules/rule/vars.tf
@@ -17,3 +17,9 @@ variable "target_event_bus_arn"{
 variable "eventbridge_role_arn"{
   type = string
 }
+
+variable "tags" {
+  type = map
+  default = {}
+  description = "Tags to apply to all created AWS resources"
+}

--- a/modules/firefly_event_driven/vars.tf
+++ b/modules/firefly_event_driven/vars.tf
@@ -13,3 +13,9 @@ variable "target_event_bus_arn"{
 variable "eventbridge_role_arn"{
   type = string
 }
+
+variable "tags" {
+  type = map
+  default = {}
+  description = "Tags to apply to all created AWS resources"
+}

--- a/modules/run_workflow/main.tf
+++ b/modules/run_workflow/main.tf
@@ -1,30 +1,3 @@
-data "terracurl_request" "firefly_login" {
-  name           = "firefly_aws_integration"
-  url            = "${var.firefly_endpoint}/account/access_keys/login"
-  method         = "POST"
-  headers        = {
-    Content-Type: "application/json",
-  }
-  request_body = jsonencode({ "accessKey"=var.firefly_access_key,  "secretKey"=var.firefly_secret_key })
-
-}
-
-output "token" {
-  value = jsondecode(data.terracurl_request.firefly_login.response).access_token
-}
-
-output "response_code" {
-  value = data.terracurl_request.firefly_login.response
-}
-
-resource "time_sleep" "wait_10_seconds" {
-  depends_on = [
-    data.terracurl_request.firefly_login
-  ]
-
-  create_duration = "10s"
-}
-
 resource "terracurl_request" "firefly_run_workflow_request" {
   name           = "firefly run workflow on aws provider integration"
   url            = "${var.firefly_endpoint}/integrations/aws/runWorkflow"
@@ -39,7 +12,7 @@ resource "terracurl_request" "firefly_run_workflow_request" {
 
   headers = {
     Content-Type = "application/json"
-    Authorization: "Bearer ${jsondecode(data.terracurl_request.firefly_login.response).access_token}"
+    Authorization: "Bearer ${var.firefly_token}"
   }
 
    lifecycle {
@@ -58,7 +31,4 @@ resource "terracurl_request" "firefly_run_workflow_request" {
 
   destroy_request_body =  ""
   destroy_response_codes = [200]
-   depends_on = [
-    time_sleep.wait_10_seconds
-  ]
 }

--- a/modules/run_workflow/vars.tf
+++ b/modules/run_workflow/vars.tf
@@ -1,11 +1,6 @@
-variable "firefly_access_key" {
-  type        = string
-  description = "Your authentication access_key"
-}
-
-variable "firefly_secret_key" {
-  type        = string
-  description = "Your authentication secret_key"
+variable "firefly_token" {
+  type = string
+  description = "Token returned as result of login request"
 }
 
 variable "name" {

--- a/modules/s3_iac_events/vars.tf
+++ b/modules/s3_iac_events/vars.tf
@@ -24,3 +24,9 @@ variable "prefix"{
   default = ""
   description = "The s3 object prefix to produce notifications from"
 }
+
+variable "tags" {
+  type = map
+  default = {}
+  description = "Tags to apply to all created AWS resources"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,11 +1,6 @@
-variable "firefly_access_key" {
-  type        = string
-  description = "Your authentication access_key"
-}
-
-variable "firefly_secret_key" {
-  type        = string
-  description = "Your authentication secret_key"
+variable "firefly_token" {
+  type = string
+  description = "Token returned as result of login request"
 }
 
 variable "name" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,8 +1,3 @@
-variable "firefly_token" {
-  type = string
-  description = "Token returned as result of login request"
-}
-
 variable "name" {
   type        = string
   description = "Name of the AWS integration"
@@ -11,6 +6,24 @@ variable "name" {
 variable "role_external_id" {
   type        = string
   description = "The External Id for the Firefly role generated"
+}
+
+variable "firefly_token" {
+  type = string
+  description = "Token returned as result of login request"
+  default = ""
+}
+
+variable "firefly_access_key" {
+  type        = string
+  description = "Your authentication access_key"
+  default = ""
+}
+
+variable "firefly_secret_key" {
+  type        = string
+  description = "Your authentication secret_key"
+  default = ""
 }
 
 variable "firefly_endpoint" {

--- a/variables.tf
+++ b/variables.tf
@@ -99,3 +99,9 @@ variable "enable_evntbridge_permissions" {
   default = true
   description = "enable firefly eventbridge permissions"
 }
+
+variable "tags" {
+  type = map
+  default = {}
+  description = "Tags to apply to all created AWS resources"
+}


### PR DESCRIPTION
motivation: prevent rate limiting when integrating several accounts

changes to support:

- create new module firefly_auth which outputs refresh token
- expose token variable to main module

Bonus:
expose optional tags variable to apply a map of tags to each applicable resource