### PR TITLE
feat: allow running multienv

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,14 @@ exist_integration = true
 ```
 
 ### Optional
-You can add optionally add tags to each relevant resource:
+You can optionally add tags to each relevant resource:
 ```
 tags = {vendor: "firefly"}
+```
+
+You can optionally add a prefix to all created resource:
+```
+resource_prefix = "prod-"
 ```
 
 AWS credentials will be default unless adding one of the following params to the configuration:

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,8 @@
+locals {
+  firefly_role_name = "${var.resource_prefix}${var.firefly_role_name}"
+  firefly_deny_list_policy_name = "${var.resource_prefix}${var.firefly_deny_list_policy_name}"
+}
+
 provider "aws" {
   alias      = "ap_northeast_1"
   region     = "ap-northeast-1"
@@ -436,25 +441,27 @@ module "firefly_aws_integration" {
   firefly_token = length(module.firefly_auth) > 0 ? module.firefly_auth[0].firefly_token : var.firefly_token
   name = var.name
   firefly_endpoint = var.firefly_endpoint
+  firefly_organization_id = var.firefly_organization_id
   event_driven = var.is_event_driven
   target_event_bus_arn = var.target_event_bus_arn
   is_prod = var.is_prod
   full_scan_enabled = var.full_scan_enabled
   role_external_id = var.role_external_id
-  role_name = var.firefly_role_name
-  firefly_deny_list_policy_name = var.firefly_deny_list_policy_name
+  role_name = local.firefly_role_name
+  firefly_deny_list_policy_name = local.firefly_deny_list_policy_name
   terraform_create_rules = var.terraform_create_rules
   event_driven_regions = var.event_driven_regions
   providers          = {
     aws = aws.us_east_1
   }
+  resource_prefix = var.resource_prefix
 }
 
 module "firefly_eventbridge_permissions" {
   count = var.enable_evntbridge_permissions ? 1 : 0
   source = "./modules/eventbridge_permissions"
   target_event_bus_arn = var.target_event_bus_arn
-  firefly_role_name = var.firefly_role_name
+  firefly_role_name = local.firefly_role_name
   depends_on = [
     module.firefly_aws_integration
   ]
@@ -462,6 +469,7 @@ module "firefly_eventbridge_permissions" {
     aws = aws.us_east_1
   }
   tags = var.tags
+  resource_prefix = var.resource_prefix
 }
 
 // create eventbridge rules using workflow for exist integration
@@ -494,6 +502,7 @@ module "event_driven_ap_northeast_1" {
     aws = aws.ap_northeast_1
   }
   tags = var.tags
+  resource_prefix = var.resource_prefix
 }
 
 module "event_driven_ap_northeast_2" {
@@ -511,6 +520,7 @@ module "event_driven_ap_northeast_2" {
     aws = aws.ap_northeast_2
   }
   tags = var.tags
+  resource_prefix = var.resource_prefix
 }
 
 module "event_driven_ap_northeast_3" {
@@ -527,8 +537,8 @@ module "event_driven_ap_northeast_3" {
   providers      = {
     aws = aws.ap_northeast_3
   }
-
   tags = var.tags
+  resource_prefix = var.resource_prefix
 }
 
 module "event_driven_ap_south_1" {
@@ -546,6 +556,7 @@ module "event_driven_ap_south_1" {
     aws = aws.ap_south_1
   }
   tags = var.tags
+  resource_prefix = var.resource_prefix
 }
 
 module "event_driven_ap_southeast_1" {
@@ -563,6 +574,7 @@ module "event_driven_ap_southeast_1" {
     aws = aws.ap_southeast_1
   }
   tags = var.tags
+  resource_prefix = var.resource_prefix
 }
 
 module "event_driven_ap_southeast_2" {
@@ -580,6 +592,7 @@ module "event_driven_ap_southeast_2" {
     aws = aws.ap_southeast_2
   }
   tags = var.tags
+  resource_prefix = var.resource_prefix
 }
 
 module "event_driven_ca_central_1" {
@@ -597,6 +610,7 @@ module "event_driven_ca_central_1" {
     aws = aws.ca_central_1
   }
   tags = var.tags
+  resource_prefix = var.resource_prefix
 }
 
 module "event_driven_eu_central_1" {
@@ -615,6 +629,7 @@ module "event_driven_eu_central_1" {
   }
 
   tags = var.tags
+  resource_prefix = var.resource_prefix
 }
 
 module "event_driven_eu_north_1" {
@@ -632,6 +647,7 @@ module "event_driven_eu_north_1" {
     aws = aws.eu_north_1
   }
   tags = var.tags
+  resource_prefix = var.resource_prefix
 }
 
 module "event_driven_eu_west_1" {
@@ -650,6 +666,7 @@ module "event_driven_eu_west_1" {
   }
 
   tags = var.tags
+  resource_prefix = var.resource_prefix
 }
 
 module "event_driven_eu_west_2" {
@@ -667,6 +684,7 @@ module "event_driven_eu_west_2" {
     aws = aws.eu_west_2
   }
   tags = var.tags
+  resource_prefix = var.resource_prefix
 }
 
 module "event_driven_eu_west_3" {
@@ -684,6 +702,7 @@ module "event_driven_eu_west_3" {
     aws = aws.eu_west_3
   }
   tags = var.tags
+  resource_prefix = var.resource_prefix
 }
 
 module "event_driven_sa_east_1" {
@@ -701,6 +720,7 @@ module "event_driven_sa_east_1" {
     aws = aws.sa_east_1
   }
   tags = var.tags
+  resource_prefix = var.resource_prefix
 }
 
 module "event_driven_us_east_1" {
@@ -718,6 +738,7 @@ module "event_driven_us_east_1" {
     aws = aws.us_east_1
   }
   tags = var.tags
+  resource_prefix = var.resource_prefix
 }
 
 module "event_driven_us_east_2" {
@@ -735,6 +756,7 @@ module "event_driven_us_east_2" {
     aws = aws.us_east_2
   }
   tags = var.tags
+  resource_prefix = var.resource_prefix
 }
 
 module "event_driven_us_west_1" {
@@ -752,6 +774,7 @@ module "event_driven_us_west_1" {
     aws = aws.us_west_1
   }
   tags = var.tags
+  resource_prefix = var.resource_prefix
 }
 
 module "event_driven_us_west_2" {
@@ -769,6 +792,7 @@ module "event_driven_us_west_2" {
     aws = aws.us_west_2
   }
   tags = var.tags
+  resource_prefix = var.resource_prefix
 }
 
 module "iac_events_ap_northeast_1" {
@@ -962,10 +986,11 @@ module "config_service_setup" {
   depends_on = [module.firefly_aws_integration]
   count = var.use_config_service ? 1 : 0
   source = "./modules/config_service_setup"
-  firefly_deny_policy_name = var.firefly_deny_list_policy_name
+  firefly_deny_policy_name = local.firefly_deny_list_policy_name
   providers = {
     aws = aws.us_east_1
   }
-  firefly_role_name = var.firefly_role_name
+  firefly_role_name = local.firefly_role_name
   tags = var.tags
+  resource_prefix = var.resource_prefix
 }

--- a/modules/config_service_setup/main.tf
+++ b/modules/config_service_setup/main.tf
@@ -1,7 +1,7 @@
 data "aws_caller_identity" "current" {}
 
 resource "aws_iam_policy" "config_service_management_policy" {
-  name        = "ConfigServiceManagementPolicy"
+  name        = "${var.resource_prefix}ConfigServiceManagementPolicy"
   path        = "/"
   description = "this policy allows the config service to use it's s3 bucket to store the service's data"
   policy      = jsonencode({
@@ -36,7 +36,7 @@ resource "aws_iam_policy" "config_service_management_policy" {
 }
 
 resource "aws_iam_role" "aws_config_role" {
-  name                = "aws-config-role-firefly"
+  name                = "${var.resource_prefix}aws-config-role-firefly"
   description         = "this role allows the config service a read only permissions to the cloud configuration, and permissions to it's s3 bucket"
   assume_role_policy  = <<POLICY
 {
@@ -63,13 +63,13 @@ POLICY
 }
 
 resource "aws_s3_bucket" "config_bucket" {
-  bucket        = "aws-config-service-bucket-${data.aws_caller_identity.current.account_id}"
+  bucket        = "${var.resource_prefix}aws-config-service-bucket-${data.aws_caller_identity.current.account_id}"
   force_destroy = true
   tags = var.tags
 }
 
 resource "aws_iam_policy" "config_service_firefly_permissions" {
-  name        = "fireflyConfigServicePermissions"
+  name        = "${var.resource_prefix}fireflyConfigServicePermissions"
   path        = "/"
   description = "this policy allows firefly to create/stop/delete a configuration recorder"
   policy      = jsonencode({

--- a/modules/config_service_setup/vars.tf
+++ b/modules/config_service_setup/vars.tf
@@ -11,3 +11,9 @@ variable "tags" {
   default = {}
   description = "Tags to apply to all created AWS resources"
 }
+
+variable "resource_prefix" {
+  type = string
+  default = ""
+  description = "Prefix to add to all resources created"
+}

--- a/modules/eventbridge_permissions/main.tf
+++ b/modules/eventbridge_permissions/main.tf
@@ -5,7 +5,7 @@ locals {
 }
 
 resource "aws_iam_policy" "firefly_eventbridge_permission" {
-  name        = "fireflyEventDrivenRulesPermission"
+  name        = "${var.resource_prefix}fireflyEventDrivenRulesPermission"
   path        = "/"
   description = "permission to put eventbridge rules"
 
@@ -43,7 +43,7 @@ resource "aws_iam_role_policy_attachment" "firefly_eventbridge_permissions" {
 
 // this role is dedicated for events service
 resource "aws_iam_role" "invoke_firefly_event_bus" {
-  name               = "invoke-firefly-remote-event-bus"
+  name               = "${var.resource_prefix}invoke-firefly-remote-event-bus"
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -62,7 +62,7 @@ EOF
 }
 
 resource "aws_iam_policy" "invoke_firefly_event_bus" {
-  name   = "invoke-firefly-remote-event-bus"
+  name   = "${var.resource_prefix}invoke-firefly-remote-event-bus"
   policy = jsonencode({
     "Version": "2012-10-17",
     "Statement": [

--- a/modules/eventbridge_permissions/vars.tf
+++ b/modules/eventbridge_permissions/vars.tf
@@ -11,3 +11,9 @@ variable "tags" {
   default = {}
   description = "Tags to apply to all created AWS resources"
 }
+
+variable "resource_prefix" {
+  type = string
+  default = ""
+  description = "Prefix to add to all resources created"
+}

--- a/modules/firefly_aws_integration/iam.tf
+++ b/modules/firefly_aws_integration/iam.tf
@@ -161,7 +161,7 @@ locals {
 }
 
 resource "aws_iam_policy" "firefly_s3_specific_permission" {
-  name        = "S3SpecificReadPermission"
+  name        = "${var.resource_prefix}S3SpecificReadPermission"
   path        = "/"
   description = "Read only permission for the Specific S3 Buckets"
 
@@ -202,7 +202,7 @@ resource "aws_iam_role" "firefly_cross_account_access_role" {
      {
         "Action" : "sts:AssumeRole",
         "Principal" : {
-          "AWS" : "arn:aws:iam::${local.organizationID}:root"
+          "AWS" : "arn:aws:iam::${var.firefly_organization_id}:root"
         },
         "Effect" : "Allow",
         "Condition": {

--- a/modules/firefly_aws_integration/locals.tf
+++ b/modules/firefly_aws_integration/locals.tf
@@ -1,4 +1,3 @@
 locals {
   version = "0.1.0"
-  organizationID= "094724549126"
 }

--- a/modules/firefly_aws_integration/vars.tf
+++ b/modules/firefly_aws_integration/vars.tf
@@ -45,7 +45,7 @@ variable "event_driven"{
 }
 
 variable "target_event_bus_arn"{
-    type = string
+  type = string
 }
 
 variable "role_external_id" {
@@ -82,4 +82,16 @@ variable "tags" {
   type = map
   default = {}
   description = "Tags to apply to all created AWS resources"
+}
+
+variable "resource_prefix" {
+  type = string
+  default = ""
+  description = "Prefix to add to all resources created"
+}
+
+variable "firefly_organization_id" {
+  type = string
+  default = "094724549126"
+  description = "AWS account ID to allow assume role from"
 }

--- a/modules/firefly_event_driven/main.tf
+++ b/modules/firefly_event_driven/main.tf
@@ -21,4 +21,4 @@ module "no_actions_rule" {
     target_event_bus_arn = var.target_event_bus_arn
     eventbridge_role_arn = var.eventbridge_role_arn
     tags = var.tags
-} 
+}

--- a/modules/firefly_event_driven/modules/eventbridge_rule/main.tf
+++ b/modules/firefly_event_driven/modules/eventbridge_rule/main.tf
@@ -12,4 +12,5 @@ module "rule" {
     }
   })
   tags = var.tags
+  resource_prefix = var.resource_prefix
 }

--- a/modules/firefly_event_driven/modules/eventbridge_rule/vars.tf
+++ b/modules/firefly_event_driven/modules/eventbridge_rule/vars.tf
@@ -31,3 +31,9 @@ variable "tags" {
   default = {}
   description = "Tags to apply to all created AWS resources"
 }
+
+variable "resource_prefix" {
+  type = string
+  default = ""
+  description = "Prefix to add to all resources created"
+}

--- a/modules/firefly_event_driven/modules/no_actions_eventbridge_rule/main.tf
+++ b/modules/firefly_event_driven/modules/no_actions_eventbridge_rule/main.tf
@@ -12,4 +12,5 @@ module "rule" {
     }
   })
   tags = var.tags
+  resource_prefix = var.resource_prefix
 }

--- a/modules/firefly_event_driven/modules/no_actions_eventbridge_rule/vars.tf
+++ b/modules/firefly_event_driven/modules/no_actions_eventbridge_rule/vars.tf
@@ -27,3 +27,9 @@ variable "tags" {
   default = {}
   description = "Tags to apply to all created AWS resources"
 }
+
+variable "resource_prefix" {
+  type = string
+  default = ""
+  description = "Prefix to add to all resources created"
+}

--- a/modules/firefly_event_driven/modules/rule/main.tf
+++ b/modules/firefly_event_driven/modules/rule/main.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudwatch_event_rule" "rule" {
-  name        = "firefly-events-${var.rule_name}"
+  name        = "${var.resource_prefix}firefly-events-${var.rule_name}"
   description = "${var.service} Cloud Trail to Firefly event bus"
   event_pattern = var.event_pattarn
   tags = var.tags
@@ -7,7 +7,7 @@ resource "aws_cloudwatch_event_rule" "rule" {
 
 resource "aws_cloudwatch_event_target" "target" {
   rule      = aws_cloudwatch_event_rule.rule.name
-  target_id = "SendToExternalEventBus"
+  target_id = "${var.resource_prefix}SendToExternalEventBus"
   arn       = var.target_event_bus_arn
   role_arn  = var.eventbridge_role_arn
 }

--- a/modules/firefly_event_driven/modules/rule/vars.tf
+++ b/modules/firefly_event_driven/modules/rule/vars.tf
@@ -23,3 +23,9 @@ variable "tags" {
   default = {}
   description = "Tags to apply to all created AWS resources"
 }
+
+variable "resource_prefix" {
+  type = string
+  default = ""
+  description = "Prefix to add to all resources created"
+}

--- a/modules/firefly_event_driven/vars.tf
+++ b/modules/firefly_event_driven/vars.tf
@@ -19,3 +19,9 @@ variable "tags" {
   default = {}
   description = "Tags to apply to all created AWS resources"
 }
+
+variable "resource_prefix" {
+  type = string
+  default = ""
+  description = "Prefix to add to all resources created"
+}

--- a/modules/run_workflow/vars.tf
+++ b/modules/run_workflow/vars.tf
@@ -22,3 +22,9 @@ variable event_driven_regions {
   type        = list(string)
   description = "The list of regions to install firefly event driven in"
 }
+
+variable "resource_prefix" {
+  type = string
+  default = ""
+  description = "Prefix to add to all resources created"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -118,3 +118,15 @@ variable "tags" {
   default = {}
   description = "Tags to apply to all created AWS resources"
 }
+
+variable "resource_prefix" {
+  type = string
+  default = ""
+  description = "Prefix to add to all resources created"
+}
+
+variable "firefly_organization_id" {
+  type = string
+  default = "094724549126"
+  description = "FireFly AWS account ID to allow assume role from, do not override unless explicitly needed"
+}


### PR DESCRIPTION
motivation: Allow installing the module against multiple environments concurrently

changes to support:
- expose `resource_prefix` variable to allow adding a set prefix to all created resources
- expose `firefly_organization_id` to configure aws account