### PR TITLE
fix: broken auth module validation not allowing usage

### DIFF
--- a/modules/firefly_auth/vars.tf
+++ b/modules/firefly_auth/vars.tf
@@ -9,7 +9,7 @@ variable "firefly_access_key" {
   description = "Your authentication access_key"
   validation {
     condition = var.firefly_access_key != ""
-    error_message = "firefly_access_key cannot be empty"
+    error_message = "Variable `firefly_access_key` cannot be empty."
   }
 }
 
@@ -18,6 +18,6 @@ variable "firefly_secret_key" {
   description = "Your authentication secret_key"
   validation {
     condition = var.firefly_secret_key != ""
-    error_message = "firefly_secret_key cannot be empty"
+    error_message = "Variable firefly_secret_key cannot be empty."
   }
 }


### PR DESCRIPTION
Auth module is broken and not allowing any modules to be pushed. This needs to be adjusted so that it passes Terraform basic validation.

This validation is needed for lower versions of Terraform (since I didn't notice a version restriction on this module as well, so this would need to be adjusted)