### PR TITLE
add missing kms:DescribeKey to firefly role

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,7 @@
 locals {
   firefly_role_name = "${var.resource_prefix}${var.firefly_role_name}"
   firefly_deny_list_policy_name = "${var.resource_prefix}${var.firefly_deny_list_policy_name}"
+  firefly_readonly_policy_name = "${var.resource_prefix}${var.firefly_readonly_policy_name}"
 }
 
 provider "aws" {
@@ -448,6 +449,7 @@ module "firefly_aws_integration" {
   full_scan_enabled = var.full_scan_enabled
   role_external_id = var.role_external_id
   role_name = local.firefly_role_name
+  firefly_readonly_policy_name = local.firefly_readonly_policy_name
   firefly_deny_list_policy_name = local.firefly_deny_list_policy_name
   terraform_create_rules = var.terraform_create_rules
   event_driven_regions = var.event_driven_regions

--- a/modules/firefly_aws_integration/iam.tf
+++ b/modules/firefly_aws_integration/iam.tf
@@ -260,6 +260,3 @@ resource "aws_iam_role_policy_attachment" "firefly_security_audit" {
   role       = aws_iam_role.firefly_cross_account_access_role.name
   policy_arn = "arn:aws:iam::aws:policy/SecurityAudit"
 }
-
-
-

--- a/modules/firefly_aws_integration/iam.tf
+++ b/modules/firefly_aws_integration/iam.tf
@@ -4,6 +4,26 @@ locals {
   account_id = data.aws_caller_identity.current.account_id
 }
 
+resource "aws_iam_policy" "firefly_readonly_policy_additional" {
+  name        = var.firefly_readonly_policy_name
+  path        = "/"
+  description = "Additional read only permissions for the cloud configuration"
+
+  policy = jsonencode({
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+          "Action": [
+            "kms:DescribeKey",
+          ],
+          "Effect": "Allow",
+          "Resource": "*"
+        },
+    ]
+  })
+  tags = var.tags
+}
+
 resource "aws_iam_policy" "firefly_readonly_policy_deny_list" {
   name        = var.firefly_deny_list_policy_name
   path        = "/"
@@ -216,6 +236,11 @@ resource "aws_iam_role" "firefly_cross_account_access_role" {
   tags = var.tags
 }
 
+resource "aws_iam_role_policy_attachment" "firefly_readonly_policy_additional" {
+  role       = aws_iam_role.firefly_cross_account_access_role.name
+  policy_arn = aws_iam_policy.firefly_readonly_policy_additional.arn
+}
+
 resource "aws_iam_role_policy_attachment" "firefly_readonly_policy_deny_list" {
   role       = aws_iam_role.firefly_cross_account_access_role.name
   policy_arn = aws_iam_policy.firefly_readonly_policy_deny_list.arn
@@ -235,3 +260,6 @@ resource "aws_iam_role_policy_attachment" "firefly_security_audit" {
   role       = aws_iam_role.firefly_cross_account_access_role.name
   policy_arn = "arn:aws:iam::aws:policy/SecurityAudit"
 }
+
+
+

--- a/modules/firefly_aws_integration/vars.tf
+++ b/modules/firefly_aws_integration/vars.tf
@@ -40,7 +40,7 @@ variable "full_scan_enabled" {
 
 variable "event_driven"{
   type = bool
-  default = false 
+  default = false
   description = "Is event driven infrastructre installed?"
 }
 
@@ -56,6 +56,11 @@ variable "role_external_id" {
 variable "role_name"{
   type        = string
   description = "The name for the Firefly role generated"
+}
+
+variable "firefly_readonly_policy_name"{
+  type        = string
+  description = "The name for the Firefly additional allow policy generated"
 }
 
 variable "firefly_deny_list_policy_name"{

--- a/variables.tf
+++ b/variables.tf
@@ -49,12 +49,18 @@ variable "firefly_role_name" {
   type    = string
 }
 
+variable "firefly_readonly_policy_name" {
+  type        = string
+  description = "The name for the Firefly allow policy generated"
+  default     = "FireflyReadonlyPolicyAllowList"
+}
+
 variable "firefly_deny_list_policy_name" {
   type        = string
   description = "The name for the Firefly deny policy generated"
   default     = "FireflyReadonlyPolicyDenyList"
 }
- 
+
 variable full_scan_enabled {
   type        = bool
   default     = true


### PR DESCRIPTION
Currently the firefly-caa-role is unable to describe KMS keys. This adds an additional policy to the role to explicitly allow it.

The following are examples of audit logs where access is denied for kms keys:

```
{
  "arn": "arn:aws:sts::xxxxx:assumed-role/firefly-caa-role/yyyyy",
  "eventSource": "kms.amazonaws.com",
  "eventName": "DescribeKey",
  "errorCode": "AccessDenied",
  "errorMessage": "User: arn:aws:sts::xxxxx:assumed-role/firefly-caa-role/yyyyy is not authorized to perform: kms:DescribeKey on resource: arn:aws:kms:us-east-1:xxxxx:key/aaaaa because no resource-based policy allows the kms:DescribeKey action"
}
{
  "arn": "arn:aws:sts::xxxxx:assumed-role/firefly-caa-role/yyyyy",
  "eventSource": "kms.amazonaws.com",
  "eventName": "DescribeKey",
  "errorCode": "AccessDenied",
  "errorMessage": "User: arn:aws:sts::xxxxx:assumed-role/firefly-caa-role/yyyyy is not authorized to perform: kms:DescribeKey on resource: arn:aws:kms:us-east-1:xxxxx:key/bbbbb because no resource-based policy allows the kms:DescribeKey action"
}
```

Currently kms keys in question are marked as Ghost resources due to being unable to be discovered