### PR TITLE
Allow scoping s3 iac buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ enable_iac_auto_discover = true
 ```
 
 ### Control Over S3 Buckets To Read tfstate Files From
-By default all S3 buckets are scanned for tfstate files. To limit the scope to a closed list set the list set:
+By default all S3 buckets are scanned for tfstate files. To limit the scope to a closed list of s3 buckets:
 ```
 allowed_s3_iac_buckets = ["bucket1", "bucket2", "bucket3"]
 ```

--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ In order to be able to control whether to create the integration with IaC auto d
 enable_iac_auto_discover = true
 ```
 
+### Control Over S3 Buckets To Read tfstate Files From
+By default all S3 buckets are scanned for tfstate files. To limit the scope to a closed list set the list set:
+```
+allowed_s3_iac_buckets = ["bucket1", "bucket2", "bucket3"]
+```
+
 ### Remove Event Driven from Existing Integration
 In order to remove event-driven for an existing integration just call the module with:
 ```

--- a/main.tf
+++ b/main.tf
@@ -456,6 +456,7 @@ module "firefly_aws_integration" {
   }
   resource_prefix = var.resource_prefix
   should_autodiscover_disabled = !var.enable_iac_auto_discover
+  allowed_s3_iac_buckets = var.allowed_s3_iac_buckets
 }
 
 module "invoke_firefly_permissions" {

--- a/modules/firefly_aws_integration/iam.tf
+++ b/modules/firefly_aws_integration/iam.tf
@@ -180,6 +180,14 @@ resource "aws_iam_policy" "firefly_s3_specific_permission" {
       },
       {
         "Action" : [
+          "s3:ListObjects",
+          "s3:ListObjectsV2",
+        ],
+        "Effect" : "Deny",
+        "NotResource" : local.s3_objects_to_allow
+      },
+      {
+        "Action" : [
           "s3:GetObject"
         ],
         "Effect" : "Deny",

--- a/modules/firefly_aws_integration/iam.tf
+++ b/modules/firefly_aws_integration/iam.tf
@@ -155,11 +155,10 @@ resource "aws_iam_policy" "firefly_readonly_policy_deny_list" {
 
 locals {
   allowed_buckets = length(var.allowed_s3_iac_buckets) > 0 ? [for value in var.allowed_s3_iac_buckets : "arn:aws:s3:::${value}/*tfstate"] : ["arn:aws:s3:::*/*tfstate"]
-  s3_objects         = [
+  s3_objects         = concat([
     "arn:aws:s3:::elasticbeanstalk*/*",
     "arn:aws:s3:::aws-emr-resources*/*",
-    allowed_buckets[*],
-  ]
+  ], local.allowed_buckets)
   config_service_objects = ["arn:aws:s3:::*/${data.aws_caller_identity.current.account_id}*ConfigSnapshot*.json.gz"]
   s3_objects_to_allow = var.use_config_service ?  concat(local.s3_objects, local.config_service_objects) : local.s3_objects
 }

--- a/modules/firefly_aws_integration/iam.tf
+++ b/modules/firefly_aws_integration/iam.tf
@@ -154,13 +154,39 @@ resource "aws_iam_policy" "firefly_readonly_policy_deny_list" {
 }
 
 locals {
-  allowed_buckets = length(var.allowed_s3_iac_buckets) > 0 ? [for value in var.allowed_s3_iac_buckets : "arn:aws:s3:::${value}/*tfstate"] : ["arn:aws:s3:::*/*tfstate"]
-  s3_objects         = concat([
+  allowed_objects = length(var.allowed_s3_iac_buckets) > 0 ? [for value in var.allowed_s3_iac_buckets : "arn:aws:s3:::${value}/*tfstate"] : ["arn:aws:s3:::*/*tfstate"]
+  aws_managed_buckets = [    
     "arn:aws:s3:::elasticbeanstalk*/*",
-    "arn:aws:s3:::aws-emr-resources*/*",
-  ], local.allowed_buckets)
+    "arn:aws:s3:::aws-emr-resources*/*"
+  ]
+  s3_objects = concat(local.aws_managed_buckets, local.allowed_objects)
+  allowed_list_objects = concat(
+    length(var.allowed_s3_iac_buckets) > 0 ? [for value in var.allowed_s3_iac_buckets : "arn:aws:s3:::${value}"] : [],
+    local.aws_managed_buckets
+  )
   config_service_objects = ["arn:aws:s3:::*/${data.aws_caller_identity.current.account_id}*ConfigSnapshot*.json.gz"]
   s3_objects_to_allow = var.use_config_service ?  concat(local.s3_objects, local.config_service_objects) : local.s3_objects
+}
+
+resource "aws_iam_policy" "explicit_deny_s3_object_list" {
+  count = length(var.allowed_s3_iac_buckets) > 0 ? 1 : 0
+  name        = "${var.resource_prefix}ExplicitDenyS3ObjectList"
+  path        = "/"
+  description = "Deny list for S3 objects"
+
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Action" : [
+          "s3:ListBucket"
+        ],
+        "Effect" : "Deny",
+        "NotResource" : local.allowed_list_objects
+      }
+    ]
+  })
+  tags = var.tags
 }
 
 resource "aws_iam_policy" "firefly_s3_specific_permission" {
@@ -177,14 +203,6 @@ resource "aws_iam_policy" "firefly_s3_specific_permission" {
         ],
         "Effect" : "Allow",
         "Resource" : "arn:aws:kms:*:${local.account_id}:key/*"
-      },
-      {
-        "Action" : [
-          "s3:ListObjects",
-          "s3:ListObjectsV2",
-        ],
-        "Effect" : "Deny",
-        "NotResource" : local.s3_objects_to_allow
       },
       {
         "Action" : [
@@ -277,4 +295,12 @@ resource "aws_iam_role_policy_attachment" "firefly_additional_fetching_permissio
   policy_arn = aws_iam_policy.firefly_additional_fetching_permission.arn
   # attach policies serialy
   depends_on = [ aws_iam_role_policy_attachment.firefly_security_audit ]
+}
+
+resource "aws_iam_role_policy_attachment" "firefly_explicit_deny_s3_object_list" {
+  count = length(var.allowed_s3_iac_buckets) > 0 ? 1 : 0
+  role       = aws_iam_role.firefly_cross_account_access_role.name
+  policy_arn = aws_iam_policy.explicit_deny_s3_object_list[count.index].arn
+  # attach policies serialy
+  depends_on = [ aws_iam_role_policy_attachment.firefly_additional_fetching_permission ]
 }

--- a/modules/firefly_aws_integration/iam.tf
+++ b/modules/firefly_aws_integration/iam.tf
@@ -154,10 +154,11 @@ resource "aws_iam_policy" "firefly_readonly_policy_deny_list" {
 }
 
 locals {
+  allowed_buckets = length(var.allowed_s3_iac_buckets) > 0 ? [for value in var.allowed_s3_iac_buckets : "arn:aws:s3:::${value}/*tfstate"] : ["arn:aws:s3:::*/*tfstate"]
   s3_objects         = [
-    "arn:aws:s3:::*/*tfstate",
     "arn:aws:s3:::elasticbeanstalk*/*",
-    "arn:aws:s3:::aws-emr-resources*/*"
+    "arn:aws:s3:::aws-emr-resources*/*",
+    allowed_buckets[*],
   ]
   config_service_objects = ["arn:aws:s3:::*/${data.aws_caller_identity.current.account_id}*ConfigSnapshot*.json.gz"]
   s3_objects_to_allow = var.use_config_service ?  concat(local.s3_objects, local.config_service_objects) : local.s3_objects

--- a/modules/firefly_aws_integration/vars.tf
+++ b/modules/firefly_aws_integration/vars.tf
@@ -84,6 +84,12 @@ variable "should_autodiscover_disabled" {
   default     = false
 }
 
+variable "allowed_s3_iac_buckets" {
+  type        = list(string)
+  description = "The list of S3 buckets to allow Firefly to read state files from. Omit to allow all buckets."
+  default     = []
+}
+
 variable "tags" {
   type = map
   default = {}

--- a/variables.tf
+++ b/variables.tf
@@ -32,6 +32,12 @@ variable "enable_iac_auto_discover" {
   default     = true
 }
 
+variable "allowed_s3_iac_buckets" {
+  type        = list(string)
+  description = "The list of S3 buckets to allow Firefly to read state files from. Omit to allow all buckets."
+  default     = []
+}
+
 variable "firefly_endpoint" {
   type        = string
   description = "The Firefly endpoint to register account management"


### PR DESCRIPTION
Motivation: Allow option to only scan a closed list of buckets for IAC states

Changes To support:
- expose new var `allowed_s3_iac_buckets`
- when set: 
  - existing `S3SpecificReadPermission` allows only these buckets rather than wild card
```
{
    "Statement": [
        {
            "Action": [
                "s3:ListBucket"
            ],
            "Effect": "Deny",
            "NotResource": [
                "arn:aws:s3:::nir-tf-state-tesst",
                "arn:aws:s3:::nir-tf-state-tesst-2",
                "arn:aws:s3:::elasticbeanstalk*/*",
                "arn:aws:s3:::aws-emr-resources*/*"
            ]
        }
    ],
    "Version": "2012-10-17"
}
```
   - new policy `ExplicitDenyS3ObjectList `and attachment deny's listing s3 objects that are not in the closed list
```
{
    "Statement": [
        {
            "Action": [
                "kms:Decrypt"
            ],
            "Effect": "Allow",
            "Resource": "arn:aws:kms:*:123456789:key/*"
        },
        {
            "Action": [
                "s3:GetObject"
            ],
            "Effect": "Deny",
            "NotResource": [
                "arn:aws:s3:::elasticbeanstalk*/*",
                "arn:aws:s3:::aws-emr-resources*/*",
                "arn:aws:s3:::nir-tf-state-tesst/*tfstate",
                "arn:aws:s3:::nir-tf-state-tesst-2/*tfstate",
                "arn:aws:s3:::*/123456789*ConfigSnapshot*.json.gz"
            ]
        },
        {
            "Action": [
                "s3:PutBucketNotification"
            ],
            "Effect": "Allow",
            "NotResource": "arn:aws:s3:::*"
        }
    ],
    "Version": "2012-10-17"
}
```
