### PR TITLE
Update outputs.tf

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,8 +24,8 @@ module "firefly_aws_integration" {
   event_driven_regions          = var.event_driven_regions
   resource_prefix               = var.resource_prefix
   should_autodiscover_disabled  = !var.enable_iac_auto_discover
-  allowed_s3_iac_buckets        = []
-  tags = merge(var.tags, local.tags)
+  allowed_s3_iac_buckets        = var.allowed_s3_iac_buckets
+  tags                          = merge(var.tags, local.tags)
 }
 
 # Eventdriven Setup: allow eventbridge to send events to firefly
@@ -33,8 +33,8 @@ module "invoke_firefly_permissions" {
   count                = var.is_event_driven && !var.bulk_onboarding ? 1 : 0
   source               = "./modules/invoke_firefly_permissions"
   target_event_bus_arn = var.target_event_bus_arn
-  tags = merge(var.tags, local.tags)
-  resource_prefix = var.resource_prefix
+  tags                 = merge(var.tags, local.tags)
+  resource_prefix      = var.resource_prefix
 }
 
 # Eventdriven Setup: allow firefly to create eventbridge rules
@@ -45,7 +45,7 @@ module "firefly_eventbridge_permissions" {
   depends_on = [
     module.invoke_firefly_permissions
   ]
-  tags = merge(var.tags, local.tags)
+  tags            = merge(var.tags, local.tags)
   resource_prefix = var.resource_prefix
 }
 

--- a/modules/firefly_aws_integration/iam.tf
+++ b/modules/firefly_aws_integration/iam.tf
@@ -215,7 +215,7 @@ resource "aws_iam_policy" "firefly_s3_specific_permission" {
           "s3:PutBucketNotification"
         ],
         "Effect" : "Allow",
-        "NotResource" : "arn:aws:s3:::*"
+        "Resource" : "arn:aws:s3:::*"
       },
     ]
   })

--- a/outputs.tf
+++ b/outputs.tf
@@ -6,5 +6,5 @@ output "firefly_integration_role_name" {
 }
 
 output "discovered_accounts" {
-  value = length(module.aws-bulk-integrations[0].discovered_accounts) > 0 ? module.aws-bulk-integrations[0].discovered_accounts : null
+  value = try(length(module.aws-bulk-integrations[0].discovered_accounts), 0) > 0 ? module.aws-bulk-integrations[0].discovered_accounts : null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,18 +1,18 @@
 variable "name" {
   type        = string
   description = "Name of the AWS integration"
-  default = ""
+  default     = ""
 }
 
 variable "region" {
-  type = string
+  type    = string
   default = "us-east-1"
 }
 
 variable "role_external_id" {
   type        = string
   description = "The External Id for the Firefly role generated"
-  default = ""
+  default     = ""
 }
 
 variable "firefly_token" {
@@ -124,12 +124,12 @@ variable "target_event_bus_arn" {
 }
 
 variable "concurrency_mode" {
-  type = string
+  type    = string
   default = "SOFT_FAILURE_TOLERANCE"
 }
 
 variable "failure_tolerance_count" {
-  type = number
+  type    = number
   default = 1
 }
 
@@ -146,17 +146,22 @@ variable "resource_prefix" {
 }
 
 variable "org_ou_ids" {
-  type = list(string)
+  type    = list(string)
   default = [""]
 }
 
 variable "bulk_onboarding" {
-  type = bool
+  type    = bool
   default = false
 }
 
 variable "max_concurrent_deploys" {
-  type = number
+  type    = number
   default = 1
 }
 
+variable "allowed_s3_iac_buckets" {
+  type        = list(string)
+  description = "The list of S3 buckets to allow Firefly to read state files from. Omit to allow all buckets."
+  default     = []
+}


### PR DESCRIPTION
Hi there! When I use the module like that:

```hcl
module "firefly-auth" {
  source             = "github.com/gofireflyio/terraform-firefly-aws-onboarding?ref=v2.13.0/modules/firefly_auth"
  firefly_access_key = "dummy"
  firefly_secret_key = "dummy"
}

module "firefly" {
  source           = "github.com/gofireflyio/terraform-firefly-aws-onboarding?ref=v2.13.0"
  firefly_token    = module.firefly-auth.firefly_token
  name             = "AWS"
  is_prod          = false
  role_external_id = "dummy"

  event_driven_regions = ["us-east-1", "us-east-2", "us-west-1", "us-west-2", "af-south-1", "ap-east-1", "ap-south-1", "ap-south-2", "ap-southeast-1", "ap-southeast-2", "ap-southeast-3", "ap-northeast-1", "ap-northeast-2", "ap-northeast-3", "ca-central-1", "cn-north-1", "cn-northwest-1", "eu-central-1", "eu-west-1", "eu-west-2", "eu-west-3", "eu-south-1", "eu-south-2", "eu-north-1", "me-south-1", "me-central-1", "sa-east-1", "il-central-1"]


  # \\ Auto Discovery - Onboard multiple accounts using Stackset
  # \\ org_ou_ids         = var.org_ou_ids
  # \\ bulk_onboarding    = true
  # \\ region             = "us-east-1"
}
```

I receive the following issue:

```hcl
Plan: 12 to add, 0 to change, 0 to destroy.
╷
│ Error: Invalid index
│ 
│   on .terraform/modules/firefly/outputs.tf line 9, in output "discovered_accounts":
│    9:   value = length(module.aws-bulk-integrations[0].discovered_accounts) > 0 ? module.aws-bulk-integrations[0].discovered_accounts : null
│     ├────────────────
│     │ module.aws-bulk-integrations is empty tuple
│ 
│ The given key does not identify an element in this collection value: the
│ collection has no elements.
```

Please approve the PR with remediation.