### PR TITLE
Specific set of tags set on IAM Role

### DIFF
--- a/_single.tf
+++ b/_single.tf
@@ -22,6 +22,7 @@ module "firefly_aws_integration" {
   allowed_s3_buckets      = var.allowed_s3_buckets
   allowed_kms_keys        = var.allowed_kms_keys
   tags                    = merge(var.tags, local.tags)
+  role_tags               = var.role_tags
   debug                   = var.debug
 }
 

--- a/modules/firefly_aws_integration/iam.tf
+++ b/modules/firefly_aws_integration/iam.tf
@@ -11,7 +11,7 @@ locals {
   allowed_kms_keys   = length(var.allowed_kms_keys) > 0 ? var.allowed_kms_keys : ["arn:aws:kms:*:${local.account_id}:key/*"]
   allowed_s3_objects = length(var.allowed_s3_buckets) > 0 ? [for value in var.allowed_s3_buckets : "arn:aws:s3:::${value}/*tfstate"] : ["arn:aws:s3:::*/*tfstate"]
   allowed_s3_buckets = concat(
-      length(var.allowed_s3_buckets) > 0 ? [for value in var.allowed_s3_buckets : "arn:aws:s3:::${value}"] : [],
+    length(var.allowed_s3_buckets) > 0 ? [for value in var.allowed_s3_buckets : "arn:aws:s3:::${value}"] : [],
     local.aws_managed_buckets
   )
 }
@@ -268,7 +268,7 @@ resource "aws_iam_role" "firefly_cross_account_access_role" {
       }
     ]
   })
-  tags = var.tags
+  tags = merge(var.tags, var.role_tags)
 }
 
 resource "aws_iam_role_policy_attachment" "firefly_readonly_policy_deny_list" {

--- a/modules/firefly_aws_integration/vars.tf
+++ b/modules/firefly_aws_integration/vars.tf
@@ -35,11 +35,9 @@ variable "role_name" {
   description = "The name for the Firefly role generated"
 }
 
-
 variable "event_driven_regions" {
   type = list(string)
 }
-
 
 variable "allowed_s3_buckets" {
   type        = list(string)
@@ -59,6 +57,12 @@ variable "tags" {
   description = "Tags to apply to all created AWS resources"
 }
 
+variable "role_tags" {
+  type        = map(any)
+  default     = {}
+  description = "Tags to apply to created AWS roles"
+}
+
 variable "resource_prefix" {
   type        = string
   default     = ""
@@ -66,9 +70,9 @@ variable "resource_prefix" {
 }
 
 variable "debug" {
-  type = bool
+  type        = bool
   description = "Enable debug mode"
-  default = false
+  default     = false
 }
 
 variable "firefly_organization_id" {

--- a/modules/stackset-onboarding/vars.tf
+++ b/modules/stackset-onboarding/vars.tf
@@ -22,9 +22,9 @@ variable "cloudformation_template_url" {
 }
 
 variable "debug" {
-  type = bool
+  type        = bool
   description = "Enable debug mode"
-  default = false
+  default     = false
 }
 
 variable "endpoint" {

--- a/terraform.tf
+++ b/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.12.1, <= 5.66.0"
+      version = ">= 4.12.1, < 6.0.0"
     }
 
     http = {

--- a/variables.tf
+++ b/variables.tf
@@ -114,6 +114,12 @@ variable "tags" {
   description = "Tags to apply to all created AWS resources"
 }
 
+variable "role_tags" {
+  type        = map(any)
+  default     = {}
+  description = "Tags to apply to created AWS roles"
+}
+
 variable "resource_prefix" {
   type        = string
   default     = ""
@@ -126,9 +132,9 @@ variable "org_ou_ids" {
 }
 
 variable "debug" {
-  type = bool
+  type        = bool
   description = "Enable debug mode"
-  default = false
+  default     = false
 }
 
 variable "stackset" {


### PR DESCRIPTION
We require our roles to have a specific set of tags.
So far there was not an option to set this.

Also I have moved the upper bound of the aws provider to next major version.
This is causing issues and limiting whole states to use 5.66.0 if this module is part of them.