### PR TITLE
Remove the upper limit on the aws provider version

### DIFF
--- a/terraform.tf
+++ b/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.12.1, < 6.0.0"
+      version = ">= 4.12.1"
     }
 
     http = {


### PR DESCRIPTION
Remove the upper limit on the aws provider version to prevent updates to v6 and higher. 

The minimum version required should be enough (and is used in the module `versions.tf`)